### PR TITLE
feat: add "Run Terminal by Name" command for keybinding support

### DIFF
--- a/.changeset/run-terminal-by-name.md
+++ b/.changeset/run-terminal-by-name.md
@@ -1,0 +1,11 @@
+---
+"terminal-keeper": minor
+---
+
+Add "Run Terminal by Name" command for keybinding support
+
+- New command `terminal-keeper.run-terminal-by-name` that allows running a specific terminal by name
+- Supports keybinding args: `{ "name": "terminal-name", "session": "optional-session" }`
+- Shows QuickPick with all available terminals when `name` is not provided
+- Filters terminals by session when `session` is provided without `name`
+- Resolves issue #67

--- a/README.md
+++ b/README.md
@@ -226,6 +226,23 @@ focus?: boolean,
 disabled?: boolean
 ```
 
+### Keybinding Support
+
+Run specific terminals directly via keyboard shortcuts by adding custom keybindings to your `keybindings.json`:
+
+```json
+{
+    "key": "ctrl+shift+t",
+    "command": "terminal-keeper.run-terminal-by-name",
+    "args": { "name": "dev-server", "session": "default" }
+}
+```
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `name` | No | Terminal name to run. If omitted, shows a picker with all available terminals. |
+| `session` | No | Limit search to a specific session. |
+
 ### Optional: Hide Terminal Commands in Explorer Descriptions
 
 By default, Terminal Keeper shows the commands for each terminal as a description in the explorer tree view. If you prefer a cleaner look, you can hide these descriptions by setting the following option in your VS Code settings:

--- a/package.json
+++ b/package.json
@@ -213,6 +213,11 @@
             {
                 "command": "terminal-keeper.import-from-gulp",
                 "title": "From gulp (e.g. gulpfile.mjs, gulpfile.js, GULPFILE.js)"
+            },
+            {
+                "command": "terminal-keeper.run-terminal-by-name",
+                "category": "Terminal Keeper",
+                "title": "Run Terminal by Name"
             }
         ],
         "menus": {

--- a/src/commands/runTerminalByNameAsync.ts
+++ b/src/commands/runTerminalByNameAsync.ts
@@ -1,0 +1,119 @@
+import { QuickPickItem, window } from 'vscode';
+import { Configuration } from '../configuration/configuration';
+import { SessionItem } from '../configuration/interface';
+import { constants } from '../utils/constants';
+import { findTerminalByName } from '../utils/find-terminal-in-config';
+import { showErrorMessageWithDetail, showGenerateConfiguration } from '../utils/utils';
+import { activeByTerminalAsync } from './activeByTerminalAsync';
+
+export interface RunTerminalByNameArgs {
+    name?: string;
+    session?: string;
+}
+
+interface TerminalQuickPickItem extends QuickPickItem {
+    terminalName: string | undefined;
+    sessionId: string;
+    index: number;
+}
+
+const getTerminalQuickPickItems = (sessions: { [key: string]: SessionItem[] }): TerminalQuickPickItem[] => {
+    const items: TerminalQuickPickItem[] = [];
+
+    for (const [sessionId, sessionItems] of Object.entries(sessions)) {
+        if (!sessionItems || !Array.isArray(sessionItems)) {
+            continue;
+        }
+
+        for (let index = 0; index < sessionItems.length; index++) {
+            const item = sessionItems[index];
+            const baseItem = { description: `Session: ${sessionId}`, sessionId, index };
+
+            if (Array.isArray(item)) {
+                // Terminal group
+                items.push({
+                    ...baseItem,
+                    label: `$(split-horizontal) ${item.map((t) => t.name).join(', ')}`,
+                    detail: 'Terminal group (split)',
+                    terminalName: undefined
+                });
+            } else if (item.name) {
+                // Single terminal
+                const commandsPreview = Array.isArray(item.commands) ? item.commands.join('; ') : '';
+                items.push({
+                    ...baseItem,
+                    label: `$(terminal) ${item.name}`,
+                    detail: commandsPreview || '(no commands)',
+                    terminalName: item.name
+                });
+            }
+        }
+    }
+
+    return items;
+};
+
+export const runTerminalByNameAsync = async (args: RunTerminalByNameArgs): Promise<void> => {
+    try {
+        let { name, session } = args || {};
+
+        // If no name provided, show QuickPick with available terminals
+        if (!name) {
+            const isDefinedSessionFile = await Configuration.isDefinedSessionFile();
+            if (!isDefinedSessionFile) {
+                await showGenerateConfiguration();
+                return;
+            }
+
+            const config = await Configuration.load();
+            if (!config?.sessions) {
+                window.showWarningMessage(constants.notExistAnySessions);
+                return;
+            }
+
+            // If session provided, filter to only that session
+            const sessionsToShow = session
+                ? { [session]: config.sessions[session] }
+                : config.sessions;
+
+            const items = getTerminalQuickPickItems(sessionsToShow);
+            if (items.length === 0) {
+                window.showWarningMessage(constants.notExistAnySessions);
+                return;
+            }
+
+            const selected = await window.showQuickPick(items, {
+                title: constants.selectTerminalTitle,
+                placeHolder: constants.selectTerminalPlaceHolder,
+                canPickMany: false,
+                ignoreFocusOut: true,
+                matchOnDescription: true,
+                matchOnDetail: true
+            });
+
+            if (!selected) {
+                return; // User cancelled
+            }
+
+            // Use index directly from QuickPick selection - no search needed
+            await activeByTerminalAsync(selected.sessionId, selected.index, selected.terminalName);
+            return;
+        }
+
+        // Name provided via keybinding args - need to search for it
+        const result = await findTerminalByName(name, session);
+
+        if (!result) {
+            const message = session
+                ? constants.terminalNotFound.replace('{name}', name).replace('{session}', session)
+                : constants.terminalNotFoundInAny.replace('{name}', name);
+            window.showWarningMessage(message);
+            return;
+        }
+
+        const terminalName = Array.isArray(result.terminal) ? undefined : name;
+        await activeByTerminalAsync(result.sessionId, result.index, terminalName);
+    } catch (error) {
+        showErrorMessageWithDetail(constants.runTerminalByNameFailed, error);
+    }
+};

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,7 @@ import { migrateAsync } from './commands/migrateAsync';
 import { navigateAsync } from './commands/navigateAsync';
 import { openAsync } from './commands/openAsync';
 import { removeAsync } from './commands/removeAsync';
+import { runTerminalByNameAsync, RunTerminalByNameArgs } from './commands/runTerminalByNameAsync';
 import { saveAsync } from './commands/saveAsync';
 import { Configuration } from './configuration/configuration';
 import { configFileVersions } from './configuration/interface';
@@ -60,6 +61,10 @@ export async function activate(context: ExtensionContext) {
         // Kill all terminals
         commands.registerCommand(extCommands.killAll, async (...args: any[]) => {
             await killAllAsync();
+        }),
+        // Run terminal by name
+        commands.registerCommand(extCommands.runTerminalByName, async (args: RunTerminalByNameArgs) => {
+            await runTerminalByNameAsync(args);
         })
     );
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -23,7 +23,8 @@ export const extCommands = {
     copyCommandActivity: 'terminal-keeper.copy-command-activity',
     collapseAllActivity: 'terminal-keeper.collapse-all-activity',
     navigateActivity: 'terminal-keeper.navigate-activity',
-    helpAndFeedbackActivity: 'terminal-keeper.help-and-feedback-activity'
+    helpAndFeedbackActivity: 'terminal-keeper.help-and-feedback-activity',
+    runTerminalByName: 'terminal-keeper.run-terminal-by-name'
 };
 
 export const ACTIVITY_VIEW_ID = 'terminalKeeperActivityView';
@@ -99,6 +100,13 @@ export const constants = {
 
     // Migrate the configuration file
     migrateConfigurationFailed: 'The attempt to upgrade to the most recent configuration file schema was unsuccessful!',
+
+    // Run terminal by name
+    selectTerminalTitle: 'Select a terminal to run',
+    selectTerminalPlaceHolder: 'Select terminal...',
+    terminalNotFound: 'Terminal "{name}" not found in session "{session}".',
+    terminalNotFoundInAny: 'Terminal "{name}" not found in any session.',
+    runTerminalByNameFailed: 'Failed to run terminal by name.',
 
     // The components
     yesButton: 'Yes',

--- a/src/utils/find-terminal-in-config.ts
+++ b/src/utils/find-terminal-in-config.ts
@@ -54,3 +54,47 @@ export const findTerminal = async (
     }
     return foundTerminal;
 };
+
+export const findTerminalByName = async (
+    terminalName: string,
+    sessionId?: string
+): Promise<{ terminal: TerminalItem | TerminalItem[]; sessionId: string; index: number } | undefined> => {
+    // Check if session file exists
+    const isDefinedSessionFile = await Configuration.isDefinedSessionFile();
+    if (!isDefinedSessionFile) {
+        return undefined;
+    }
+
+    // Load the configuration
+    const config = await Configuration.load();
+    if (!config?.sessions) {
+        return undefined;
+    }
+
+    // Determine which sessions to search
+    const sessionsToSearch = sessionId
+        ? { [sessionId]: config.sessions[sessionId] }
+        : config.sessions;
+
+    // Search for terminal by name
+    for (const [sid, sessionItems] of Object.entries(sessionsToSearch)) {
+        if (!sessionItems) {
+            continue;
+        }
+
+        for (let index = 0; index < sessionItems.length; index++) {
+            const item = sessionItems[index];
+
+            if (Array.isArray(item)) {
+                // Check if any terminal in group matches
+                const found = item.find((t) => t.name === terminalName);
+                if (found) {
+                    return { terminal: item, sessionId: sid, index };
+                }
+            } else if (item.name === terminalName) {
+                return { terminal: item, sessionId: sid, index };
+            }
+        }
+    }
+    return undefined;
+};


### PR DESCRIPTION
## Summary

Add "Run Terminal by Name" command with keybinding support to resolve #67.

This allows users to run specific terminals directly via keyboard shortcuts, without needing to navigate through session selection.

## Demo

**Running via keybinding:**

https://github.com/user-attachments/assets/9854820d-8a7b-4b2e-946a-21c1989ebad9

**Running via Command Palette:**

https://github.com/user-attachments/assets/d42f96e6-da50-462a-9bea-af15e704f91b

## Changes

- New command `terminal-keeper.run-terminal-by-name`
- Accepts optional `name` and `session` arguments
- Shows QuickPick picker when `name` is omitted
- Filters terminals by session when `session` is provided
- Added `findTerminalByName()` helper function
- Updated README with keybinding documentation

## Usage

Add to `keybindings.json`:

```json
{
    "key": "ctrl+shift+t",
    "command": "terminal-keeper.run-terminal-by-name",
    "args": { "name": "dev-server", "session": "default" }
}
```

| Argument | Required | Description |
|----------|----------|-------------|
| `name` | No | Terminal name to run. If omitted, shows a picker. |
| `session` | No | Limit search to a specific session. |

## Test plan

- [x] Run command from Command Palette (should show terminal picker)
- [x] Run command with keybinding `{ "name": "single-terminal" }`
- [x] Run command with keybinding `{ "name": "grouped-terminal" }` (should open all terminals in group)
- [x] Run command with keybinding `{ "name": "terminal-name", "session": "session-name" }`
- [x] Run command with keybinding `{ "session": "default" }` (should show filtered picker)
